### PR TITLE
Investigate homepage video carousel click issue

### DIFF
--- a/components/trailer-section.tsx
+++ b/components/trailer-section.tsx
@@ -69,7 +69,8 @@ export function TrailerSection() {
     const dx = currentX - touchStartX.current;
     const dy = currentY - touchStartY.current;
 
-    if (!isDragging.current) {
+    // Only mark as dragging if there's significant movement
+    if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
       isDragging.current = true;
     }
 
@@ -82,7 +83,12 @@ export function TrailerSection() {
   };
 
   const handleTouchEnd = () => {
-    if (!isDragging.current) return;
+    // Only process swipe if there was significant dragging movement
+    if (!isDragging.current) {
+      // This was a tap/click, not a swipe - let it pass through to the iframe
+      return;
+    }
+    
     const deltaX = touchStartX.current - touchEndX.current;
 
     // Higher threshold for mobile swipe
@@ -115,18 +121,10 @@ export function TrailerSection() {
             <div 
               ref={containerRef}
               className="relative aspect-video bg-card/50 backdrop-blur-sm rounded-lg border border-border/50 overflow-hidden card-enhanced"
+              onTouchStart={isMobile ? handleTouchStart : undefined}
+              onTouchMove={isMobile ? handleTouchMove : undefined}
+              onTouchEnd={isMobile ? handleTouchEnd : undefined}
             >
-              {/* Swipe overlay on mobile to capture gestures above iframe */}
-              {isMobile && (
-                <div
-                  className="absolute inset-0 z-10 touch-pan-y"
-                  onTouchStart={handleTouchStart}
-                  onTouchMove={handleTouchMove}
-                  onTouchEnd={handleTouchEnd}
-                  aria-label="Swipe to change trailer"
-                />
-              )}
-              
               <iframe 
                 key={trailers[currentTrailer].id}
                 src={trailers[currentTrailer].url} 


### PR DESCRIPTION
Allow video playback on mobile by removing a blocking overlay and refining touch event handling.

On mobile, a transparent overlay div with `z-index: 10` was covering the video player, preventing users from clicking to play videos. This PR removes the blocking overlay, moves touch event listeners directly to the video container, and improves the touch detection logic to differentiate between taps (allowing video interaction) and swipes (for changing videos).

---
<a href="https://cursor.com/background-agent?bcId=bc-614b25a6-9ea3-4ce7-a233-f86f15fe6ee0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-614b25a6-9ea3-4ce7-a233-f86f15fe6ee0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

